### PR TITLE
Update special constants specification.

### DIFF
--- a/definition/syncor.tex
+++ b/definition/syncor.tex
@@ -26,7 +26,7 @@ may not (except~~{\tt =}~) be used as identifiers.
 a non-empty sequence of decimal digits
 $\boxml{0},\twoldots,\boxml{9}$ and the underscore (\wildpat) that
 neither starts nor ends with an underscore.
-An\index{6.2} {\sl integer constant} is an optional negation symbol
+An\index{6.2} {\sl integer constant (in decimal notation)} is an optional negation symbol
 (\tttilde) followed by a positive integer constant. }{%
 An\index{6.2} {\sl integer constant (in
 decimal notation)} is an optional negation symbol (\tttilde)
@@ -36,25 +36,25 @@ An {\sl integer constant (in
 hexadecimal notation)} is an optional negation symbol
 followed by \boxml{0x} followed by a non-empty sequence of
 hexadecimal digits $\boxml{0},\twoldots,\boxml{9}$
-and $\boxml{a},\twoldots,\boxml{f}$\ADD{, and the underscore that does not
-end with an underscore}.
+and $\boxml{a},\twoldots,\boxml{f}$\ADD{ and the underscore that neither starts nor ends
+ends with an underscore}.
 ($\boxml{A},\twoldots,\boxml{F}$
 may be used as alternatives for $\boxml{a},\twoldots,\boxml{f}$.)
 \ADD{
 An {\sl integer constant (in binary notation)} is an optional negation
-symbol followed by a non-empty sequence of binary digits \boxml{0}, \boxml{1},
-and the underscore that does not end with an underscore.
+symbol followed by \boxml{0b} followed by a non-empty sequence of binary digits $\boxml{0},\boxml{1}$
+and the underscore that neither starts nor ends with an underscore.
 }
 
 A {\sl word constant (in decimal notation)} is \boxml{0w}  followed
-by a non-empty sequence of decimal digits\ADD{ and the underscore that does not
-end with an underscore}.
+by a non-empty sequence of decimal digits\ADD{ and the underscore that neither starts nor
+ends with an underscore}.
 A {\sl word constant
 (in hexadecimal notation)} is \boxml{0wx} followed by a non-empty
-sequence of hexadecimal digits\ADD{ and the underscore that does not
-end with an underscore}.
+sequence of hexadecimal digits\ADD{ and the underscore that neither starts nor
+ends with an underscore}.
 \ADD{A word constant (in binary notation) is \boxml{0wb} followed by a non-empty
-sequence of binary digits \boxml{0}, \boxml{1}, and the underscore not ending with
+sequence of binary digits and the underscore that neither starts nor ends with
 an underscore.}
 
 A {\sl real constant} is an integer constant in decimal notation,


### PR DESCRIPTION
Minor update to the specification of special constants:
- a binary integer requires an `0b` prefix
- sequences of digits and underscores should neither start nor end with
  an underscore.

These correspond to the support in SML/NJ and MLton.  In particular,
they rule out

```
0wx_FF_FF
```

where an underscore immediately follows the prefix (much as an
underscore cannot immediately precede or follow `.` or `e` in a real
constant).
