### PR TITLE
Minor tweaks to wording

### DIFF
--- a/definition/app2.tex
+++ b/definition/app2.tex
@@ -112,7 +112,7 @@ match.
 
 \item[\textcolor{\addcolor}{$\bullet$}]
 \ADD{Likewise, a conditional ``\IF\ $\exp_1$ \THEN\ $\cdots$'' extends as far right as possible,
-which means that optional \ELSE\ branches group with innermost conditional.}
+which means that optional \ELSE\ branches group with the innermost conditional.}
 \end{itemize}
 
 \FIX{%

--- a/definition/app2.tex
+++ b/definition/app2.tex
@@ -129,7 +129,7 @@ We impose the following additional restrictions on the syntax:}
     \FIX{In a $\fmatch$ with $m$ rules, the expressions $\exp_1,\,\ldots,\,\exp_{m-1}$
     must not end in a $\match$.}
   \item[\textcolor{\addcolor}{$\bullet$}]
-    \ADD{The pattern \pat\ in a \valbind\ may not nested match or guard, unless enclosed
+    \ADD{The pattern \pat\ in a \valbind\ may not be a nested match or guard, unless enclosed
     by parentheses.}
 \end{itemize}%
 

--- a/definition/syncor.tex
+++ b/definition/syncor.tex
@@ -150,13 +150,15 @@ to range over \SCon.\index{6.4}
 
 \subsection{Comments}
 \REPL{
-A\index{7.1} {\sl comment} is either {\sl line comment} or a {\sl block comment}.
+A\index{7.1} {\sl comment} is either a {\sl line comment} or a {\sl block comment}.
 A line comment is any character sequence between the comment delimiter \boxml{(*)}
 and the following end of line.
 A block comment is any character sequence within comment brackets ~{\tt (* *)}~
 in which other comments are properly nested.
-No space is allowed between the characters that make up a comment bracket
-\ml{(*)}, \ml{(*} or \ml{*)}.
+No space is allowed between the characters that make up a comment delimiter
+\ml{(*)}
+or comment bracket
+\ml{(*} or \ml{*)}.
 An unmatched \boxml{(*} should be detected by the compiler.
 }{%
 A\index{7.1} {\sl comment}


### PR DESCRIPTION
This isn't intended to change the meaning of anything. I'm pretty confident that "be a" is the right missing verb for the valbind description - but please check!