### PR TITLE
Change empty phrases to use empty optional brackets.

### DIFF
--- a/definition/app2.tex
+++ b/definition/app2.tex
@@ -38,13 +38,13 @@ The grammatical rules are displayed in Figures~\ref{exp-gram},
 The grammatical conventions are exactly as in
 Section~\ref{syn-core-sec}, namely:
 \begin{itemize}
-  \item The brackets ~$\langle\ \rangle$~ enclose optional phrases.
+  \item The brackets ~$\langle\ \rangle$~ enclose empty and optional phrases.
   \item For\index{69.3} any syntax class X (over which $x$ ranges)
 we define the syntax class Xseq (over which {\it xseq} ranges) as follows:
     \begin{quote}
     \begin{tabular}{rcll}
        {\it xseq} & $::=$ & $x$ & (singleton sequence)\\
-                  &       &     & (empty sequence)\\
+                  &       & $\langle \rangle$ & (empty sequence)\\
                   &       & \ml{(}$x_1$\ml{,}$\cdots$\ml{,}$x_n$\ml{)}
                                 & (sequence,~$n\geq 1$) \\
     \end{tabular}

--- a/definition/mac.tex
+++ b/definition/mac.tex
@@ -245,7 +245,7 @@
 \newcommand{\localdec}
            {\mbox{\LOCAL\ $\dec_1\ \IN\ \dec_2$\ \END}}
 \newcommand{\emptydec}
-           {\mbox{\qquad}}
+           {\mbox{$\langle \rangle$}}
 \newcommand{\seqdec}
            {\mbox{$\dec_1\ \langle\boxml{;}\rangle\ \dec_2$}}
 \newcommand{\longinfix}
@@ -387,7 +387,7 @@
 
         % Modules Phrases
 
-\newcommand{\emptyphrase}{\qquad}
+\newcommand{\emptyphrase}{\mbox{$\langle \rangle$}}
 
 
         % structure-level declarations

--- a/definition/syncor.tex
+++ b/definition/syncor.tex
@@ -423,13 +423,13 @@ TyRow   & type-expression rows \cr
 The following\index{10.1} conventions are adopted in presenting the grammatical rules,
 and in their interpretation:
 \begin{itemize}
-  \item The brackets\index{10.2} ~$\langle\ \rangle$~ enclose optional phrases.
+  \item The brackets\index{10.2} ~$\langle\ \rangle$~ enclose empty and optional phrases.
   \item For any syntax class X (over which $x$ ranges)
 we define the syntax class Xseq (over which {\it xseq} ranges) as follows:
     \begin{quote}
     \begin{tabular}{rcll}
        {\it xseq} & $::=$ & $x$ & (singleton sequence)\\
-                  &       &     & (empty sequence)\\
+                  & 	  & $\langle \rangle$ & (empty sequence)\\
                   &       & \ml{(}$x_1$\ml{,}$\cdots$\ml{,}$x_n$\ml{)}
                                 & (sequence,~$n\geq 1$) \\
     \end{tabular}


### PR DESCRIPTION
Not intended to make any semantic changes,
but to make the empty grammars clearer, since I seem to consistently overlook them.