### PR TITLE
Minor changes for successful typesetting

### DIFF
--- a/definition/mac.tex
+++ b/definition/mac.tex
@@ -670,10 +670,10 @@
 \newcommand{\n}{n}
 \newcommand{\N}{N}
 \newcommand{\p}{p}
-\def\r{r}
+\AtBeginDocument{\def\r{r}}
 \newcommand{\res}{\mbox{\it res}}
 \newcommand{\s}{s}
-\renewcommand{\t}{t}
+\AtBeginDocument{\renewcommand{\t}{t}}
 \newcommand{\T}{T}
 \newcommand{\U}{U}
 \newcommand{\V}{v}

--- a/definition/root.tex
+++ b/definition/root.tex
@@ -19,7 +19,7 @@
 %%
 %% support for SuccML changes
 %%
-\usepackage[deletedmarkup=xout,authormarkup=none]{changes}
+\usepackage[deletedmarkup=xout,authormarkup=none,commandnameprefix=ifneeded]{changes}
 \newcommand{\fixcolor}{blue}  % corrections to definition
 \newcommand{\addcolor}{magenta}  % new SuccML features
 \newcommand{\delcolor}{gray}


### PR DESCRIPTION
1. Due to recent addition of `\comment` command in `changes` package, `root.tex` failed to typeset.  A package option is needed to avoid name clash.
2. I like PDF hyperlinks and bookmarks, but the document didn't typeset with `\usepackage{hyperref}` uncommented.  I worked around the problem by deferring conflicting definitions of `\r` and `\t`.
