### PR TITLE
Fix specification of the derived form of record extension expression

### DIFF
--- a/definition/app1.tex
+++ b/definition/app1.tex
@@ -223,7 +223,7 @@ type-sharing constraints in the equivalent form.
 \cline{1-2}
 \ADD{\ml{...} \ml{=}\ \exp\ml{,} \labexps}
 	& \ADD{\ml{...} \ml{=} \LET\ \VAL\ \vid\ \ml{=}\ \exp\ \IN} & \ADD{(\vid\ new)}\\
-	& \ADD{\boxml{\ \ \ \ \ \ \ttlbrace}\ \labexps\ml{,}\ \vid\ \ttrbrace\ \END} \\
+	& \ADD{\boxml{\ \ \ \ \ \ \ttlbrace}\ \labexps\ml{,}\ \ml{...} \ml{=} \vid\ \ttrbrace\ \END} \\
 \cline{1-2}
 \multicolumn{2}{r}{\ADD{(see note in text concerning \labexps)}}\\
 \multicolumn{3}{c}{}\\


### PR DESCRIPTION
The desugaring of

```sml
... = exp, exprow
```

should be

```sml
... = let val vid = exp in
      { exprow, ... = vid } end
```

rather than

```sml
... = let val vid = exp in
      { exprow, vid } end
```
